### PR TITLE
(feat): Adds serialization/deserialization to PublicKey and Ciphertext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ rand_core = { version = "0.5", default-features = false }
 rand = { version = "0.6.0", default-features = true }
 sha2 = "0.8.0"
 clear_on_drop = { version = "0.2" }
+serde = { version = "1.0", features = ["derive"] }
+bincode = "1"
 
 [features]
 default = ["std", "u64_backend"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ElGamal
 
-Efficient pure-Rust library for the [ElGamal] (https://en.wikipedia.org/wiki/ElGamal_encryption) additive homomorphic
+Efficient pure-Rust library for the [ElGamal](https://en.wikipedia.org/wiki/ElGamal_encryption) additive homomorphic
 encryption scheme using the Ristretto primer order group over Curve25519. Library also supports signature following
-[EdDSA] (https://en.wikipedia.org/wiki/EdDSA).
+[EdDSA](https://en.wikipedia.org/wiki/EdDSA).
 
 **Important**: while we have followed recommendations regarding the scheme itself, this library should currently be seen
  as an experimental implementation. In particular, no particular efforts have so far been made to harden it against


### PR DESCRIPTION
This PR adds serialization and deserialization to both `PublicKey` and `Ciphertext` types. It also adds tests using `bincode`.

It also fixes the signature of `encrypt_dirty` for `pub unsafe fn encrypt_dirty(..)`, since we want to expose the method publicly.