### PR TITLE
add get_scalar for SecretKey

### DIFF
--- a/src/private.rs
+++ b/src/private.rs
@@ -37,6 +37,11 @@ impl SecretKey {
         SecretKey(clamp_scalar(bytes).reduce())
     }
 
+    /// Get scalar value
+    pub fn get_scalar(&self) -> Scalar {
+        self.0
+    }
+
     /// Decrypt ciphertexts
     pub fn decrypt(&self, ciphertext: &Ciphertext) -> RistrettoPoint {
         let (point1, point2) = ciphertext.get_points();


### PR DESCRIPTION
It is sometimes useful to get the inner scalar.

One example is debug.
Another is https://github.com/iquerejeta/bulletproofs/blob/b8c1c5559b1cc240deff30f4ed71fc1f9c9f2edb/src/range_proof/mod.rs#L599. Since the inner scalar is not public, I have no way to use the function above with SecretKey. 