### PR TITLE
chore: use `curve25519_dalek_ng` version 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ license = "MIT"
 
 
 [dependencies]
-curve25519-dalek = { version = "2.0.0", default-features = false, features = ["serde"] }
-zkp = "0.7.0"
-rand_core = { version = "0.5.1", default-features = false }
-sha2 = "0.8.0"
+curve25519-dalek-ng = { version = "3", features = ["alloc"] }
+zkp = "0.8.0"
+rand_core = { version = "0.5", features = [ "getrandom" ] }
+sha2 = "0.9.0"
 clear_on_drop = { version = "0.2" }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1"
@@ -36,6 +36,6 @@ harness = false
 
 [features]
 default = ["std", "u64_backend"]
-std = ["curve25519-dalek/std"]
-nightly = ["curve25519-dalek/nightly", "clear_on_drop/nightly"]
-u64_backend = ["curve25519-dalek/u64_backend"]
+std = ["curve25519-dalek-ng/std"]
+nightly = ["curve25519-dalek-ng/nightly", "clear_on_drop/nightly"]
+u64_backend = ["curve25519-dalek-ng/u64_backend"]

--- a/src/ciphertext.rs
+++ b/src/ciphertext.rs
@@ -1,10 +1,10 @@
 use core::ops::{Add, Div, Mul, Sub};
-use curve25519_dalek::ristretto::RistrettoPoint;
-use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek_ng::ristretto::RistrettoPoint;
+use curve25519_dalek_ng::scalar::Scalar;
 use serde::{Deserialize, Serialize};
 
 use crate::public::*;
-use curve25519_dalek::constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT};
+use curve25519_dalek_ng::constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT};
 use rand_core::OsRng;
 use zkp::{CompactProof, Transcript};
 
@@ -186,7 +186,7 @@ define_div_variants!(LHS = Ciphertext, RHS = Scalar, Output = Ciphertext);
 mod tests {
     use super::*;
     use crate::private::SecretKey;
-    use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
+    use curve25519_dalek_ng::constants::RISTRETTO_BASEPOINT_POINT;
 
     #[test]
     fn test_randomisation_and_proof() {

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,9 +1,9 @@
 #![allow(non_snake_case)]
 use clear_on_drop::clear::Clear;
 use core::ops::Mul;
-use curve25519_dalek::constants::{RISTRETTO_BASEPOINT_POINT};
-use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
-use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek_ng::constants::{RISTRETTO_BASEPOINT_POINT};
+use curve25519_dalek_ng::ristretto::{CompressedRistretto, RistrettoPoint};
+use curve25519_dalek_ng::scalar::Scalar;
 use rand_core::{CryptoRng, OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};

--- a/src/public.rs
+++ b/src/public.rs
@@ -1,8 +1,8 @@
 #![allow(non_snake_case)]
 use clear_on_drop::clear::Clear;
-use curve25519_dalek::constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT};
-use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
-use curve25519_dalek::scalar::Scalar;
+use curve25519_dalek_ng::constants::{RISTRETTO_BASEPOINT_COMPRESSED, RISTRETTO_BASEPOINT_POINT};
+use curve25519_dalek_ng::ristretto::{CompressedRistretto, RistrettoPoint};
+use curve25519_dalek_ng::scalar::Scalar;
 use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
@@ -28,8 +28,8 @@ impl PublicKey {
     /// use rand_core::OsRng;
     /// use elgamal_ristretto::public::{PublicKey, };
     /// use elgamal_ristretto::private::{SecretKey, };
-    /// use curve25519_dalek::ristretto::{RistrettoPoint, };
-    /// use curve25519_dalek::scalar::{Scalar, };
+    /// use curve25519_dalek_ng::ristretto::{RistrettoPoint, };
+    /// use curve25519_dalek_ng::scalar::{Scalar, };
     ///
     /// # fn main() {
     ///        let mut csprng = OsRng;
@@ -81,7 +81,7 @@ impl PublicKey {
     /// use rand_core::OsRng;
     /// use elgamal_ristretto::public::{PublicKey, };
     /// use elgamal_ristretto::private::{SecretKey, };
-    /// use curve25519_dalek::ristretto::RistrettoPoint;
+    /// use curve25519_dalek_ng::ristretto::RistrettoPoint;
     ///
     /// # fn main() {
     ///       // Generate key-pair
@@ -121,7 +121,7 @@ impl PublicKey {
     /// use rand_core::OsRng;
     /// use elgamal_ristretto::public::{PublicKey, };
     /// use elgamal_ristretto::private::{SecretKey, };
-    /// use curve25519_dalek::ristretto::RistrettoPoint;
+    /// use curve25519_dalek_ng::ristretto::RistrettoPoint;
     ///
     /// # fn main() {
     ///       let mut csprng = OsRng;
@@ -152,7 +152,7 @@ impl PublicKey {
     /// use rand_core::OsRng;
     /// use elgamal_ristretto::public::{PublicKey, };
     /// use elgamal_ristretto::private::{SecretKey, };
-    /// use curve25519_dalek::ristretto::RistrettoPoint;
+    /// use curve25519_dalek_ng::ristretto::RistrettoPoint;
     ///
     /// # fn main() {
     ///    let mut csprng = OsRng;
@@ -197,7 +197,7 @@ impl PublicKey {
     /// use rand_core::OsRng;
     /// use elgamal_ristretto::public::{PublicKey, };
     /// use elgamal_ristretto::private::{SecretKey, };
-    /// use curve25519_dalek::ristretto::RistrettoPoint;
+    /// use curve25519_dalek_ng::ristretto::RistrettoPoint;
     ///
     /// # fn main() {
     ///    let mut csprng = OsRng;
@@ -283,7 +283,7 @@ impl PartialEq for PublicKey {
 mod tests {
     use super::*;
     use crate::private::SecretKey;
-    use curve25519_dalek::ristretto::CompressedRistretto;
+    use curve25519_dalek_ng::ristretto::CompressedRistretto;
 
     #[test]
     fn test_encryption() {


### PR DESCRIPTION
Hey, thanks for your work on this. This PR uses `zkcrypto/curve25519-dalek-ng` on a more recent-ish version, posting this here for visibility; it might be useful to someone else. Cheers.